### PR TITLE
Fixed bugs for higher dimensions; added unit tests to uniquetol_nd

### DIFF
--- a/src/uniquetol_nd.rs
+++ b/src/uniquetol_nd.rs
@@ -3,7 +3,8 @@ use ndarray::{Array, Axis, IxDyn};
 use crate::isapprox::{EqualNan, Tols, isapprox};
 use crate::uniquetol_1d::{Occurrence, sortperm, uniquetol_1d};
 
-const SHAPE_ERR: &str = "Failed to convert unique values to ndarray";
+const SHAPE_ERR: &str = "Failed to reshape vector to ndarray";
+const CONTIG_ERR: &str = "Array is not contiguous";
 
 #[derive(Debug)]
 pub struct BoundsError {
@@ -30,18 +31,23 @@ pub enum FlattenAxis {
     Dim(usize),
 }
 
-fn uniquetol_groups(arr: &[f64], tols: Tols, equal_nan: EqualNan) -> Vec<Vec<usize>> {
+fn uniquetol_groups(
+    group: &[usize],
+    arr: &[f64],
+    tols: Tols,
+    equal_nan: EqualNan,
+) -> Vec<Vec<usize>> {
     let perm_sorted = sortperm(arr, false);
-    let mut groups = vec![vec![perm_sorted[0]]];
+    let mut groups = vec![vec![group[perm_sorted[0]]]];
     let mut curr = arr[perm_sorted[0]];
 
     for &idx in perm_sorted.iter().skip(1) {
         let next = arr[idx];
 
         match isapprox(curr, next, tols, equal_nan) {
-            true => groups.last_mut().unwrap().push(idx),
+            true => groups.last_mut().unwrap().push(group[idx]),
             false => {
-                groups.push(vec![idx]);
+                groups.push(vec![group[idx]]);
                 curr = next;
             }
         }
@@ -51,57 +57,264 @@ fn uniquetol_groups(arr: &[f64], tols: Tols, equal_nan: EqualNan) -> Vec<Vec<usi
 }
 
 #[inline]
-fn uniquetol_1d_flatten_none(
+fn uniquetol_nd_flatten_none(
     arr: &Array<f64, IxDyn>,
     tols: Tols,
     equal_nan: EqualNan,
+    occurrence: Occurrence,
 ) -> Array<f64, IxDyn> {
-    let arr_flat = arr.flatten().to_vec();
-    let arr_unique = uniquetol_1d(&arr_flat, tols, equal_nan, Occurrence::default()).arr_unique;
+    let arr_flat = arr.as_slice().expect(CONTIG_ERR);
+    let arr_unique = uniquetol_1d(arr_flat, tols, equal_nan, occurrence).arr_unique;
     let shape = IxDyn(&[arr_unique.len()]);
     Array::from_shape_vec(shape, arr_unique).expect(SHAPE_ERR)
 }
 
-fn uniquetol_1d_flatten_axis(
+fn uniquetol_nd_flatten_axis(
     arr: &Array<f64, IxDyn>,
     tols: Tols,
     equal_nan: EqualNan,
+    occurrence: Occurrence,
     axis: usize,
 ) -> Array<f64, IxDyn> {
-    let arrs_flat = arr.axis_iter(Axis(axis)).collect::<Vec<_>>();
-    let n = arrs_flat[0].len();
-    let mut groups: Vec<Vec<usize>> = vec![(0..n).collect()];
+    let arr_flat: Vec<f64> = arr
+        .axis_iter(Axis(axis))
+        .flat_map(|slice| slice.to_owned())
+        .collect();
+
+    let k = arr.len_of(Axis(axis));
+    let n = arr.len() / k;
+    let mut groups: Vec<Vec<usize>> = vec![(0..k).collect()];
+    let mut groups_new = Vec::with_capacity(k);
+    let mut sub_arr = Vec::with_capacity(n);
 
     for idx in 0..n {
-        let mut groups_new = Vec::new();
+        groups_new.clear();
 
         for group in groups.iter() {
-            let arr: Vec<f64> = group.iter().map(|&i| arrs_flat[i][idx]).collect();
-            groups_new.extend(uniquetol_groups(&arr, tols, equal_nan));
+            sub_arr.clear();
+            sub_arr.extend(group.iter().map(|&i| arr_flat[i * n + idx]));
+            groups_new.extend(uniquetol_groups(group, &sub_arr, tols, equal_nan));
         }
 
-        groups = groups_new;
+        std::mem::swap(&mut groups, &mut groups_new);
     }
 
-    let arr_unique: Vec<f64> = groups.iter().map(|group| arr[group[0]]).collect();
-    let shape = IxDyn(&[arr_unique.len()]);
-    Array::from_shape_vec(shape, arr_unique).expect(SHAPE_ERR)
+    let indices_unique: Vec<usize> = groups
+        .iter()
+        .map(|group| match occurrence {
+            Occurrence::Lowest => group[0],
+            Occurrence::Highest => group[group.len() - 1],
+        })
+        .collect();
+    arr.select(Axis(axis), &indices_unique)
 }
 
 pub fn uniquetol_nd(
     arr: &Array<f64, IxDyn>,
     tols: Tols,
     equal_nan: EqualNan,
+    occurrence: Occurrence,
     flatten_axis: FlattenAxis,
 ) -> Result<Array<f64, IxDyn>, BoundsError> {
     match flatten_axis {
-        FlattenAxis::None => Ok(uniquetol_1d_flatten_none(arr, tols, equal_nan)),
-        FlattenAxis::Dim(axis) if axis < arr.ndim() => {
-            Ok(uniquetol_1d_flatten_axis(arr, tols, equal_nan, axis))
-        }
+        FlattenAxis::None => Ok(uniquetol_nd_flatten_none(arr, tols, equal_nan, occurrence)),
+        FlattenAxis::Dim(axis) if axis < arr.ndim() => Ok(uniquetol_nd_flatten_axis(
+            arr, tols, equal_nan, occurrence, axis,
+        )),
         FlattenAxis::Dim(axis) => Err(BoundsError {
             axis,
             ndim: arr.ndim(),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::prelude::*;
+
+    const ARR_2D: [[f64; 3]; 4] = [
+        [1.000000, 2.000000, -3.000001],
+        [1.000001, 2.000001, -2.999997],
+        [-4.300000, 1.999996, -0.000000],
+        [1.000002, 2.000002, -2.999998],
+    ];
+    const SHAPE_2D: (usize, usize) = (4, 3);
+
+    const ARR_3D: [[[f64; 5]; 4]; 2] = [
+        [
+            [1.000000, 2.000000, -3.000001, 2.000002, 1.999998],
+            [1.000001, 2.000001, -2.999997, 2.000001, 1.999999],
+            [-4.300000, 1.999996, 0.000000, 1.999994, 2.000002],
+            [1.000002, -3.777777, -2.999998, -3.777774, -3.777771],
+        ],
+        [
+            [-4.300000, 1.999996, 0.000000, 1.999994, 2.000002],
+            [-4.299994, 2.000002, 0.000007, 1.999994, 2.000002],
+            [1.000002, 2.000002, -3.000001, 2.000001, 1.999999],
+            [1.000001, 2.000001, -2.999997, 2.000001, 1.999999],
+        ],
+    ];
+    const SHAPE_3D: (usize, usize, usize) = (2, 4, 5);
+
+    fn arr_2d() -> Array2<f64> {
+        Array2::from_shape_vec(
+            SHAPE_2D,
+            ARR_2D
+                .iter()
+                .flat_map(|slice| slice.iter().copied())
+                .collect(),
+        )
+        .expect(SHAPE_ERR)
+    }
+
+    fn arr_3d() -> Array3<f64> {
+        Array3::from_shape_vec(
+            SHAPE_3D,
+            ARR_3D
+                .iter()
+                .flat_map(|slice| slice.iter().flat_map(|sub_slice| sub_slice.iter().copied()))
+                .collect(),
+        )
+        .expect(SHAPE_ERR)
+    }
+
+    #[test]
+    fn test_uniquetol_2d_none() {
+        let arr = arr_2d();
+        let result = uniquetol_nd(
+            &arr.into_dyn(),
+            Tols {
+                atol: 1e-5,
+                rtol: 1e-2,
+            },
+            EqualNan::default(),
+            Occurrence::default(),
+            FlattenAxis::None,
+        )
+        .unwrap();
+        let expected = array![-4.300000, -3.000001, 0.000000, 1.000000, 1.999996];
+        assert_eq!(result, &expected.into_dyn());
+    }
+
+    #[test]
+    fn test_uniquetol_2d_0() {
+        let arr = arr_2d();
+        let result = uniquetol_nd(
+            &arr.into_dyn(),
+            Tols {
+                atol: 1e-5,
+                rtol: 1e-2,
+            },
+            EqualNan::default(),
+            Occurrence::default(),
+            FlattenAxis::Dim(0),
+        )
+        .unwrap();
+        let expected = array![
+            [-4.300000, 1.999996, -0.000000],
+            [1.000000, 2.000000, -3.000001],
+        ];
+        assert_eq!(result, &expected.into_dyn());
+    }
+
+    #[test]
+    fn test_uniquetol_2d_1() {
+        let arr = arr_2d();
+        let result = uniquetol_nd(
+            &arr.into_dyn(),
+            Tols {
+                atol: 1e-5,
+                rtol: 1e-2,
+            },
+            EqualNan::default(),
+            Occurrence::default(),
+            FlattenAxis::Dim(1),
+        )
+        .unwrap();
+        let expected = array![
+            [-3.000001, 1.000000, 2.000000],
+            [-2.999997, 1.000001, 2.000001],
+            [0.000000, -4.300000, 1.999996],
+            [-2.999998, 1.000002, 2.000002],
+        ];
+        assert_eq!(result, &expected.into_dyn());
+    }
+
+    #[test]
+    fn test_uniquetol_3d_none() {
+        let arr = arr_3d();
+        let result = uniquetol_nd(
+            &arr.into_dyn(),
+            Tols {
+                atol: 1e-5,
+                rtol: 1e-2,
+            },
+            EqualNan::default(),
+            Occurrence::Highest,
+            FlattenAxis::None,
+        )
+        .unwrap();
+        let expected = array![
+            2.000002, 1.000002, 0.000007, -2.999997, -3.777771, -4.299994
+        ];
+        assert_eq!(result, &expected.into_dyn());
+    }
+
+    #[test]
+    fn test_uniquetol_3d_0() {
+        let arr = arr_3d();
+        let result = uniquetol_nd(
+            &arr.into_dyn(),
+            Tols {
+                atol: 1e-5,
+                rtol: 1e-2,
+            },
+            EqualNan::default(),
+            Occurrence::Highest,
+            FlattenAxis::Dim(0),
+        )
+        .unwrap();
+        let shape_expected: [usize; 3] = SHAPE_3D.into();
+        assert_eq!(result.shape(), shape_expected);
+        println!("result: {:?}", result);
+    }
+
+    #[test]
+    fn test_uniquetol_3d_1() {
+        let arr = arr_3d();
+        let result = uniquetol_nd(
+            &arr.into_dyn(),
+            Tols {
+                atol: 1e-5,
+                rtol: 1e-2,
+            },
+            EqualNan::default(),
+            Occurrence::Highest,
+            FlattenAxis::Dim(1),
+        )
+        .unwrap();
+        let shape_expected = [2, 3, 5];
+        assert_eq!(result.shape(), shape_expected);
+        println!("result: {:?}", result);
+    }
+
+    #[test]
+    fn test_uniquetol_3d_2() {
+        let arr = arr_3d();
+        let result = uniquetol_nd(
+            &arr.into_dyn(),
+            Tols {
+                atol: 1e-5,
+                rtol: 1e-2,
+            },
+            EqualNan::default(),
+            Occurrence::Highest,
+            FlattenAxis::Dim(2),
+        )
+        .unwrap();
+        let shape_expected = [2, 4, 3];
+        assert_eq!(result.shape(), shape_expected);
+        println!("result: {:?}", result);
     }
 }

--- a/src/uniquetol_traits.rs
+++ b/src/uniquetol_traits.rs
@@ -23,6 +23,7 @@ pub trait UniqueTolND {
         &self,
         tols: Tols,
         equal_nan: EqualNan,
+        occurrence: Occurrence,
         flatten_axis: FlattenAxis,
     ) -> Array<f64, IxDyn>;
 }
@@ -37,9 +38,16 @@ where
         &self,
         tols: Tols,
         equal_nan: EqualNan,
+        occurrence: Occurrence,
         flatten_axis: FlattenAxis,
     ) -> Array<f64, IxDyn> {
-        uniquetol_nd(&self.mapv(|x| x).into_dyn(), tols, equal_nan, flatten_axis)
-            .expect("Failed to compute unique values")
+        uniquetol_nd(
+            &self.mapv(|x| x).into_dyn(),
+            tols,
+            equal_nan,
+            occurrence,
+            flatten_axis,
+        )
+        .expect("Failed to compute unique values")
     }
 }


### PR DESCRIPTION
Previously, uniquetol_1d worked perfectly fine, but uniquetol_nd had an unforeseen bug due to shape mismatches. Added unit tests to uniquetol_nd (still somewhat rough) to confirm bugfix. Further, added Occurrence functionality to uniquetol_nd (similarly to uniquetol_1d) and updated the API in uniquetol_traits accordingly.