### PR TITLE
Retooled the isapprox module (and dependencies)

### DIFF
--- a/src/isapprox.rs
+++ b/src/isapprox.rs
@@ -1,8 +1,24 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum EqualNan {
+pub enum NanComparison {
     #[default]
-    Yes,
-    No,
+    Equal,
+    NotEqual,
+}
+
+impl From<bool> for NanComparison {
+    fn from(value: bool) -> Self {
+        if value {
+            NanComparison::Equal
+        } else {
+            NanComparison::NotEqual
+        }
+    }
+}
+
+impl From<NanComparison> for bool {
+    fn from(value: NanComparison) -> Self {
+        matches!(value, NanComparison::Equal)
+    }
 }
 
 #[derive(Debug)]
@@ -50,19 +66,21 @@ impl Default for Tols {
 }
 
 #[inline]
-pub fn isapprox(x: f64, y: f64, tols: Tols, equal_nan: EqualNan) -> bool {
+pub fn isapprox(x: f64, y: f64, tols: Tols, nan_cmp: NanComparison) -> bool {
     if x.is_nan() && y.is_nan() {
-        return match equal_nan {
-            EqualNan::Yes => true,
-            EqualNan::No => false,
-        };
+        return nan_cmp.into();
     }
 
     if x.is_nan() || y.is_nan() {
         return false;
     }
 
-    let max_val = f64::max(f64::abs(x), f64::abs(y));
-    let max_tol = f64::max(tols.atol, tols.rtol * max_val).min(f64::MAX);
-    f64::abs(x - y) <= max_tol
+    if x == y {
+        return true;
+    }
+
+    let Tols { atol, rtol } = tols;
+    let max_val = x.abs().max(y.abs());
+    let tol = atol.max(rtol * max_val);
+    (x - y).abs() <= tol
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod uniquetol_1d;
 mod uniquetol_nd;
 mod uniquetol_traits;
 
-pub use isapprox::{EqualNan, Tols};
+pub use isapprox::{NanComparison, Tols};
 pub use uniquetol_1d::{Occurrence, UniqueTolArray};
 pub use uniquetol_nd::FlattenAxis;
 pub use uniquetol_traits::{UniqueTol1D, UniqueTolND};

--- a/src/uniquetol_1d.rs
+++ b/src/uniquetol_1d.rs
@@ -1,7 +1,7 @@
 #[path = "test_arr.rs"]
 mod test_arr;
 
-use crate::isapprox::{EqualNan, Tols, isapprox};
+use crate::isapprox::{NanComparison, Tols, isapprox};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Occurrence {
@@ -53,7 +53,7 @@ pub fn sortperm(arr: &[f64], reverse: bool) -> Vec<usize> {
 pub fn uniquetol_1d(
     arr: &[f64],
     tols: Tols,
-    equal_nan: EqualNan,
+    nan_cmp: NanComparison,
     occurrence: Occurrence,
 ) -> UniqueTolArray {
     let n = arr.len();
@@ -83,7 +83,7 @@ pub fn uniquetol_1d(
     for (i, &idx) in perm_sorted.iter().enumerate().skip(1) {
         let val = arr[idx];
 
-        match isapprox(val_curr, val, tols, equal_nan) {
+        match isapprox(val_curr, val, tols, nan_cmp) {
             true => cnt_curr += 1,
             false => {
                 indices_unique.push(perm_sorted[idx_curr]);
@@ -134,9 +134,9 @@ mod tests {
         let k: usize = 179;
 
         let tols = Tols::default();
-        let equal_nan = EqualNan::default();
+        let nan_cmp = NanComparison::default();
 
-        let uniquetol_arr = uniquetol_1d(&TEST_ARR, tols, equal_nan, occurrence);
+        let uniquetol_arr = uniquetol_1d(&TEST_ARR, tols, nan_cmp, occurrence);
 
         assert_eq!(uniquetol_arr.get_len_unique(), k);
         assert_eq!(uniquetol_arr.get_len_original(), n);
@@ -150,14 +150,14 @@ mod tests {
 
         let is_unique = arr_unique
             .windows(2)
-            .all(|w| !isapprox(w[0], w[1], tols, equal_nan));
+            .all(|w| !isapprox(w[0], w[1], tols, nan_cmp));
         assert!(is_unique);
 
         let mapped_correctly = uniquetol_arr
             .indices_unique
             .iter()
             .zip(arr_unique.iter())
-            .all(|(&idx, &x)| isapprox(TEST_ARR[idx], x, tols, equal_nan));
+            .all(|(&idx, &x)| isapprox(TEST_ARR[idx], x, tols, nan_cmp));
         assert!(mapped_correctly);
 
         let arr_remapped = uniquetol_arr.remap_to_original();
@@ -165,7 +165,7 @@ mod tests {
             && TEST_ARR
                 .iter()
                 .zip(arr_remapped.iter())
-                .all(|(&x, &y)| isapprox(x, y, tols, equal_nan));
+                .all(|(&x, &y)| isapprox(x, y, tols, nan_cmp));
         assert!(remapped_correctly);
     }
 

--- a/src/uniquetol_traits.rs
+++ b/src/uniquetol_traits.rs
@@ -1,11 +1,16 @@
 use ndarray::{Array, ArrayBase, Data, Dimension, IxDyn};
 
-use crate::isapprox::{EqualNan, Tols};
+use crate::isapprox::{NanComparison, Tols};
 use crate::uniquetol_1d::{Occurrence, UniqueTolArray, uniquetol_1d};
 use crate::uniquetol_nd::{FlattenAxis, uniquetol_nd};
 
 pub trait UniqueTol1D {
-    fn uniquetol(&self, tols: Tols, equal_nan: EqualNan, occurrence: Occurrence) -> UniqueTolArray;
+    fn uniquetol(
+        &self,
+        tols: Tols,
+        nan_cmp: NanComparison,
+        occurrence: Occurrence,
+    ) -> UniqueTolArray;
 }
 
 impl<T> UniqueTol1D for T
@@ -13,8 +18,13 @@ where
     T: AsRef<[f64]>,
 {
     #[inline]
-    fn uniquetol(&self, tols: Tols, equal_nan: EqualNan, occurrence: Occurrence) -> UniqueTolArray {
-        uniquetol_1d(self.as_ref(), tols, equal_nan, occurrence)
+    fn uniquetol(
+        &self,
+        tols: Tols,
+        nan_cmp: NanComparison,
+        occurrence: Occurrence,
+    ) -> UniqueTolArray {
+        uniquetol_1d(self.as_ref(), tols, nan_cmp, occurrence)
     }
 }
 
@@ -22,7 +32,7 @@ pub trait UniqueTolND {
     fn uniquetol(
         &self,
         tols: Tols,
-        equal_nan: EqualNan,
+        nan_cmp: NanComparison,
         occurrence: Occurrence,
         flatten_axis: FlattenAxis,
     ) -> Array<f64, IxDyn>;
@@ -37,17 +47,17 @@ where
     fn uniquetol(
         &self,
         tols: Tols,
-        equal_nan: EqualNan,
+        nan_cmp: NanComparison,
         occurrence: Occurrence,
         flatten_axis: FlattenAxis,
     ) -> Array<f64, IxDyn> {
         uniquetol_nd(
             &self.mapv(|x| x).into_dyn(),
             tols,
-            equal_nan,
+            nan_cmp,
             occurrence,
             flatten_axis,
         )
-        .expect("Failed to compute unique values")
+        .expect("Failed to compute unique values") // TODO: Make error message a const
     }
 }


### PR DESCRIPTION
Renamed the EqualNan enum (with Yes/No) to NanComparison (with Equal/NotEqual), changing variable names across the codebase accordingly. Implemented From<bool> for NanComparison and From<NanComparison> for bool for the sake of ergonomics. Refactored the code in isapprox surrounding max/abs calls, and added an early return for the x == y case.