### PR TITLE
Made typing generic across the codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,4 +86,5 @@ name = "uniquetol"
 version = "0.1.2-beta"
 dependencies = [
  "ndarray",
+ "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ license = "MIT"
 repository = "https://github.com/Luis-Varona/uniquetol-rs"
 
 [dependencies]
-ndarray = "0.16.1"
+ndarray = "0.16"
+num-traits = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,6 @@ mod uniquetol_nd;
 mod uniquetol_traits;
 
 pub use isapprox::{NanComparison, Tols};
-pub use uniquetol_1d::{Occurrence, UniqueTolArray};
+pub use uniquetol_1d::{Occurrence, UniqueTolResult};
 pub use uniquetol_nd::FlattenAxis;
 pub use uniquetol_traits::{UniqueTol1D, UniqueTolND};


### PR DESCRIPTION
isapprox, for instance, originally took in two f64's as an argument. It now takes in two inputs of generic type F: Float + Display + Debug (where Float comes from the num-traits crate). Similarly, uniquetol_1d now takes in AsRef<[F]> (where F: Float + Display + Debug) instead of specifically &[f64]. (Dependencies in uniquetol_nd and uniquetol_traits have been changed accordingly as well.)